### PR TITLE
Support local interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ docker run \
 * `-e PROXIED` - Set to `true` to make traffic go through the CloudFlare CDN. Defaults to `false`.
 * `-e RRTYPE=A` - Set to `AAAA` to use set IPv6 records instead of IPv4 records. Defaults to `A` for IPv4 records.
 * `-e DELETE_ON_STOP` - Set to `true` to have the dns record deleted when the container is stopped. Defaults to `false`.
+* `-e INTERFACE=tun0` - Set to `tun0` to have the IP pulled from a specific interface. If this is not supplied the public IP will be used. Requires `--network host` run argument.
 
 ## Multiple Domains
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker run \
 * `-e PROXIED` - Set to `true` to make traffic go through the CloudFlare CDN. Defaults to `false`.
 * `-e RRTYPE=A` - Set to `AAAA` to use set IPv6 records instead of IPv4 records. Defaults to `A` for IPv4 records.
 * `-e DELETE_ON_STOP` - Set to `true` to have the dns record deleted when the container is stopped. Defaults to `false`.
-* `-e INTERFACE=tun0` - Set to `tun0` to have the IP pulled from a specific interface. If this is not supplied the public IP will be used. Requires `--network host` run argument.
+* `-e INTERFACE=tun0` - Set to `tun0` to have the IP pulled from a network interface named `tun0`. If this is not supplied the public IP will be used. Requires `--network host` run argument.
 
 ## Multiple Domains
 

--- a/root/app/cloudflare.sh
+++ b/root/app/cloudflare.sh
@@ -9,6 +9,12 @@ cloudflare() {
     "$@"
 }
 
+getLocalIpAddress() {
+    IP_ADDRESS=$(ip addr show $INTERFACE | awk '$1 == "inet" {gsub(/\/.*$/, "", $2); print $2}')
+    
+    echo $IP_ADDRESS
+}
+
 getPublicIpAddress() {
   if [ "$RRTYPE" == "A" ]; then
     # try dns method first.

--- a/root/etc/cont-init.d/30-cloudflare-setup
+++ b/root/etc/cont-init.d/30-cloudflare-setup
@@ -37,7 +37,7 @@ echo "DNS Zone: $ZONE ($CFZoneId)"
 # Check we can get the current public ip address
 PublicIpAddress=$(getPublicIpAddress)
 
-if [ -z ${INTERFACE+x} ]; then
+if [ ! -z ${INTERFACE+x} ]; then
   PublicIpAddress=$(getLocalIpAddress)
 fi
 

--- a/root/etc/cont-init.d/30-cloudflare-setup
+++ b/root/etc/cont-init.d/30-cloudflare-setup
@@ -37,6 +37,10 @@ echo "DNS Zone: $ZONE ($CFZoneId)"
 # Check we can get the current public ip address
 PublicIpAddress=$(getPublicIpAddress)
 
+if [ -z ${INTERFACE+x} ]; then
+  PublicIpAddress=$(getLocalIpAddress)
+fi
+
 if [ "$PublicIpAddress" == "" ]; then
   echo "----------------------------------------------------------------"
   if [ "$RRTYPE" == "AAAA" ]; then

--- a/root/etc/cont-init.d/50-ddns
+++ b/root/etc/cont-init.d/50-ddns
@@ -6,6 +6,10 @@
 CurrentIpAddress=$(getPublicIpAddress)
 DnsIpAddress=$(getDnsRecordIp $CF_ZONE_ID $CF_RECORD_ID)
 
+if [ ! -z ${INTERFACE+x} ]; then
+  CurrentIpAddress=$(getLocalIpAddress)
+fi
+
 if [ "$CurrentIpAddress" != "$DnsIpAddress" ]; then
   echo "Updating CloudFlare DNS record $CF_RECORD_NAME from $DnsIpAddress to $CurrentIpAddress..."
   update=$(updateDnsRecord $CF_ZONE_ID $CF_RECORD_ID $CF_RECORD_NAME $CurrentIpAddress)


### PR DESCRIPTION
This is useful for when working with VPN that randomly assigns IP addresses to machines. The alternative is to host a local DNS server but since we have Cloudflare why bother.