### PR TITLE
Use modern Bearer login

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,18 @@ docker run \
 
 * `--restart=always` - ensure the container restarts automatically after host reboot.
 * `-e EMAIL` - Your CloudFlare email address. **Required**
-* `-e API_KEY` - Your CloudFlare API Key. Get it here: https://www.cloudflare.com/a/profile. **Required**
+* `-e API_KEY` - Your CloudFlare API Key or scoped API token. Get it here: https://www.cloudflare.com/a/profile. **Required**
 * `-e ZONE` - The DNS zone that DDNS updates should be applied to. **Required**
 * `-e SUBDOMAIN` - A subdomain of the `ZONE` to write DNS changes to. If this is not supplied the root zone will be used.
 * `-e PROXIED` - Set to `true` to make traffic go through the CloudFlare CDN. Defaults to `false`.
 * `-e RRTYPE=A` - Set to `AAAA` to use set IPv6 records instead of IPv4 records. Defaults to `A` for IPv4 records.
 * `-e DELETE_ON_STOP` - Set to `true` to have the dns record deleted when the container is stopped. Defaults to `false`.
+
+## Cloudflare API token
+
+Cloudflare prefers the usage of [scoped API tokens](https://blog.cloudflare.com/api-tokens-general-availability/). To use such a token, navigate to cloudflare settings page and create a token with the following scopes: `Zone.Zone Settings (read), Zone.Zone (read), Zone.DNS (write)`.
+
+Omit environment variable `EMAIL` and submit your generated `API_KEY`. The container will use the modern Bearer token login.
 
 ## Multiple Domains
 

--- a/root/app/cloudflare.sh
+++ b/root/app/cloudflare.sh
@@ -4,8 +4,7 @@ cloudflare() {
   curl -sSL \
     -H "Accept: application/json" \
     -H "Content-Type: application/json" \
-    -H "X-Auth-Email: $EMAIL" \
-    -H "X-Auth-Key: $API_KEY" \
+    -H "Authorization: Bearer $API_KEY" \
     "$@"
 }
 
@@ -42,7 +41,7 @@ getDnsRecordName() {
 }
 
 verifyToken() {
-  cloudflare -o /dev/null -w "%{http_code}" "$CF_API"/user
+  cloudflare -o /dev/null -w "%{http_code}" "$CF_API"/user/tokens/verify
 }
 
 getZoneId() {
@@ -58,7 +57,7 @@ createDnsRecord() {
     PROXIED="false"
   fi
 
-  cloudflare -X POST -d "{\"type\": \"$RRTYPE\",\"name\":\"$2\",\"content\":\"$3\",\"proxied\":$PROXIED}" "$CF_API/zones/$1/dns_records" | jq -r '.result.id'
+  cloudflare -X POST -d "{\"type\": \"$RRTYPE\",\"name\":\"$2\",\"content\":\"$3\",\"proxied\":$PROXIED,\"ttl\":180 }" "$CF_API/zones/$1/dns_records" | jq -r '.result.id'
 }
 
 updateDnsRecord() {
@@ -66,7 +65,7 @@ updateDnsRecord() {
     PROXIED="false"
   fi
 
-  cloudflare -X PUT -d "{\"type\": \"$RRTYPE\",\"name\":\"$3\",\"content\":\"$4\",\"proxied\":$PROXIED}" "$CF_API/zones/$1/dns_records/$2" | jq -r '.result.id'
+  cloudflare -X PUT -d "{\"type\": \"$RRTYPE\",\"name\":\"$3\",\"content\":\"$4\",\"proxied\":$PROXIED,\"ttl\":180 }" "$CF_API/zones/$1/dns_records/$2" | jq -r '.result.id'
 }
 
 deleteDnsRecord() {

--- a/root/app/cloudflare.sh
+++ b/root/app/cloudflare.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/with-contenv sh
 
 cloudflare() {
-  curl -sSL \
-    -H "Accept: application/json" \
-    -H "Content-Type: application/json" \
-    -H "Authorization: Bearer $API_KEY" \
-    "$@"
+  if [ -z "$EMAIL" ]
+  then
+      curl -sSL \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer $API_KEY" \
+      "$@"
+  else
+      curl -sSL \
+      -H "Accept: application/json" \
+      -H "Content-Type: application/json" \
+      -H "X-Auth-Email: $EMAIL" \
+      -H "X-Auth-Key: $API_KEY" \
+      "$@"
+  fi
+
 }
 
 getPublicIpAddress() {
@@ -41,7 +52,12 @@ getDnsRecordName() {
 }
 
 verifyToken() {
-  cloudflare -o /dev/null -w "%{http_code}" "$CF_API"/user/tokens/verify
+  if [ -z "$EMAIL" ]
+  then
+    cloudflare -o /dev/null -w "%{http_code}" "$CF_API"/user/tokens/verify
+  else
+    cloudflare -o /dev/null -w "%{http_code}" "$CF_API"/user
+  fi
 }
 
 getZoneId() {

--- a/root/etc/cont-init.d/30-cloudflare-setup
+++ b/root/etc/cont-init.d/30-cloudflare-setup
@@ -9,10 +9,17 @@ if [ "$statusCode" != "200" ]; then
   echo "----------------------------------------------------------------"
   echo "ERROR: Invalid CloudFlare Credentials - $statusCode"
   echo "----------------------------------------------------------------"
-  echo "Make sure the EMAIL and API_KEY variables are correct. You can"
-  echo "get your CloudFlare API Key here:"
+  if [ -z "$EMAIL" ]
+    then
+      echo "Make sure the API_KEY is correct. You can"
+      echo "get your scoped CloudFlare API Token here:"
+      echo "https://dash.cloudflare.com/profile/api-tokens"
+    else
+      echo "Make sure the EMAIL and API_KEY variables are correct. You can"
+      echo "get your CloudFlare API Key here:"
+     echo "https://www.cloudflare.com/a/profile"
+  fi
   echo
-  echo "https://www.cloudflare.com/a/profile"
   echo "----------------------------------------------------------------"
   exit 1
 fi


### PR DESCRIPTION
Cloudflare prefers scoped API tokens instead of global API keys (which is deprecated). This PR uses Bearer token login (no E-Mail needed). In API v4 another URL for token verification must be called. The PR also adds a mandatory parameter for creating and updating a record.

To use scoped API token, navigate to cloudflare settings and create a token with the following scopes: `Zone.Zone Settings, Zone.Zone, Zone.DNS`