### PR TITLE
Allow setting of DNS_SERVER

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ docker run \
 * `-e RRTYPE=A` - Set to `AAAA` to use set IPv6 records instead of IPv4 records. Defaults to `A` for IPv4 records.
 * `-e DELETE_ON_STOP` - Set to `true` to have the dns record deleted when the container is stopped. Defaults to `false`.
 * `-e INTERFACE=tun0` - Set to `tun0` to have the IP pulled from a network interface named `tun0`. If this is not supplied the public IP will be used instead. Requires `--network host` run argument.
+* `-e DNS_SERVER=10.0.0.2` - Set to the IP address of the DNS server you would like to use. Defaults to 1.1.1.1 otherwise. 
 
 ## Depreciated Parameters
 

--- a/root/app/cloudflare.sh
+++ b/root/app/cloudflare.sh
@@ -29,8 +29,11 @@ getLocalIpAddress() {
 
 getPublicIpAddress() {
   if [ "$RRTYPE" == "A" ]; then
+    # Use DNS_SERVER ENV variable or default to 1.1.1.1
+    DNS_SERVER=${DNS_SERVER:=1.1.1.1}
+
     # try dns method first.
-    CLOUD_FLARE_IP=$(dig +short @1.1.1.1 ch txt whoami.cloudflare +time=3 | tr -d '"')
+    CLOUD_FLARE_IP=$(dig +short @$DNS_SERVER ch txt whoami.cloudflare +time=3 | tr -d '"')
     CLOUD_FLARE_IP_LEN=${#CLOUD_FLARE_IP}
 
     # if using cloud flare fails, try opendns (some ISPs block 1.1.1.1)


### PR DESCRIPTION
This PR introduces a new ENV variable `DNS_SERVER` to allow you to override the 1.1.1.1 in cloudflare.sh. I had issues with the DNS failing otherwise, but allowing it to use one set manually (or maybe better yet, by `/etc/resolve.conf`) fixes my issue