### PR TITLE
Add support for API_KEY_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ docker run \
 
 * `--restart=always` - ensure the container restarts automatically after host reboot.
 * `-e API_KEY` - Your CloudFlare scoped API token. See the [Creating a Cloudflare API token](#creating-a-cloudflare-api-token) below. **Required**
+  * `API_KEY_FILE` - Path to load your CloudFlare scoped API token from (e.g. a Docker secret). *If both `API_KEY_FILE` and `API_KEY` are specified, `API_KEY_FILE` takes precedence.*
 * `-e ZONE` - The DNS zone that DDNS updates should be applied to. **Required**
 * `-e SUBDOMAIN` - A subdomain of the `ZONE` to write DNS changes to. If this is not supplied the root zone will be used.
 

--- a/root/app/cloudflare.sh
+++ b/root/app/cloudflare.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/with-contenv sh
 
 cloudflare() {
+  if [ -f "$API_KEY_FILE" ]; then
+      API_KEY=$(cat $API_KEY_FILE)
+  fi
+  
   if [ -z "$EMAIL" ]; then
       curl -sSL \
       -H "Accept: application/json" \


### PR DESCRIPTION
If `API_KEY_FILE` is specified, load the value of `API_KEY` from its contents. 

Fixes #50 