### PR TITLE
Revert "Upgrade to Alpine 3.13"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG S6_ARCH
-FROM oznu/s6-alpine:3.13-${S6_ARCH:-amd64}
+FROM oznu/s6-alpine:3.12-${S6_ARCH:-amd64}
 
 RUN apk add --no-cache jq curl bind-tools
 


### PR DESCRIPTION
Reverts oznu/docker-cloudflare-ddns#61

Users reporting issues on alpine 3.13. #62 