### PR TITLE
Added support for Docker Secrets for zone/subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ docker run \
 * `-e API_KEY` - Your CloudFlare scoped API token. See the [Creating a Cloudflare API token](#creating-a-cloudflare-api-token) below. **Required**
   * `API_KEY_FILE` - Path to load your CloudFlare scoped API token from (e.g. a Docker secret). *If both `API_KEY_FILE` and `API_KEY` are specified, `API_KEY_FILE` takes precedence.*
 * `-e ZONE` - The DNS zone that DDNS updates should be applied to. **Required**
+  * `ZONE_FILE` - Path to load your CloudFlare DNS Zone from (e.g. a Docker secret). *If both `ZONE_FILE` and `ZONE` are specified, `ZONE_FILE` takes precedence.*
 * `-e SUBDOMAIN` - A subdomain of the `ZONE` to write DNS changes to. If this is not supplied the root zone will be used.
+  * `SUBDOMAIN_FILE` - Path to load your CloudFlare DNS Subdomain from (e.g. a Docker secret). *If both `SUBDOMAIN_FILE` and `SUBDOMAIN` are specified, `SUBDOMAIN_FILE` takes precedence.*
 
 ## Optional Parameters
 

--- a/root/etc/cont-init.d/30-cloudflare-setup
+++ b/root/etc/cont-init.d/30-cloudflare-setup
@@ -2,6 +2,14 @@
 
 . /app/cloudflare.sh
 
+# Load ZONE and SUBDOMAIN vars from Docker Swarm secrets, if available:
+if [ -f "$SUBDOMAIN_FILE" ]; then
+    SUBDOMAIN=$(cat $SUBDOMAIN_FILE)
+fi
+if [ -f "$ZONE_FILE" ]; then
+    ZONE=$(cat $ZONE_FILE)
+fi
+
 # Verify the $EMAIL and $API_KEY env variables are valid
 statusCode=$(verifyToken)
 


### PR DESCRIPTION
Expanding on #50

Added the ability to put your `ZONE` and `SUBDOMAIN` env vars into Docker Secrets.

Feel free to test via: https://hub.docker.com/repository/docker/slothcroissant/cloudflare-ddns